### PR TITLE
initial commit - all works

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM busybox
+
+ADD directory-prep.sh /
+
+ENTRYPOINT ["/directory-prep.sh"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,27 @@
+# Copyright 2016 Samsung SDS Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+all: push
+
+TAG = 0.3
+PREFIX = quay.io/samsung_cnct/shared-logging-directory
+
+container:
+	docker build -t $(PREFIX):$(TAG) .
+
+push: container
+	docker push $(PREFIX):$(TAG)
+
+clean:
+	docker rmi $(PREFIX):$(TAG)

--- a/directory-prep.sh
+++ b/directory-prep.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+set -x
+
+#  this script assumes it is being used as part of the samsung logging system.  
+#  it doesn't make a lot of sense otherwise
+
+#  this script will create a pod specific directory in /var/log
+#  it will then create a symlink from /var/log/application to the unique directory
+#  this will prevent name collisions and allow us to collect named log files and
+#  add metadata
+
+#  assumes the host log directory is mounted to /hostlogs
+mkdir /hostlogs/${POD_NAME:-no_pod_name_set}-${POD_NAMESPACE:-no_pod_namespace_set}-${POD_IP:-no_pod_ip_set}
+
+#  assumes /log-pointer is an emptyDir mount shared between the containers
+ln -s /hostlogs/${POD_NAME:-no_pod_name_set}-${POD_NAMESPACE:-no_pod_namespace_set}-${POD_IP:-no_pod_ip_set} /log-pointer/application


### PR DESCRIPTION
this application is intended for use as an initilization container
for a kubernetes pod that will be streaming application logs to a
central service.  the central service can be found in k2-charts

the shell script expect two volumes to be mounted:
 - one is an emptyDir that is pod unique and will be shared between
the initialization pod and the application pod.  it will contain a
single symlink (application) that will point to the other volume.
this is where applications should write their logs to
 - two is a hostPath directory that is shared between both all
application pods that want to centralize their logs and the log
aggregation pod.  this will contain many directories, one for each
application pod.

the idea is that all applications will write to the common link in
the emptyDir volume.  the emptyDir is unique to each pod so no
collisions.  the hostPath mount will have a directory, created by
this script, that is unique to each pod (pod + namespace are in the
directory name).  The log aggregator will then use the directory
name to attach the pod name and namespace to each outgoing log event.